### PR TITLE
New start command

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,14 +29,19 @@ f.NewState().From("INITIALIZING").To("READY").OnEnter(func(*fsm.State) {
 }).Parallel(true)
 
 // Each state has a context that is closed before the state changes. You can use this with methods called within the state OnEnter method.
-f.NewState().From("FETCHING_DATA").To("STARTING_SERVER").OnEnter(func(s *fsm.State) {
+f.NewState().From("FETCHING_DATA").To("STARTING_SERVER").OnEnter(func(st *fsm.State) {
 	doSomething(st.Context())
 })
 
-// Handle async transitions.
-go func() {
-  for transition := range f.Transitions() {
-		transition.Do()
-	}
-}()
+// Run an action before each transition
+f.BeforeTransition(func(t *fsm.Transition) {
+	fmt.Printf(`Transition to %s`, t.To.Destination)
+})
+
+f.OnStart(func(st *fsm.State) {
+	runLaunchCode(st.Context())
+})
+
+// Start tells the state machine to enter the initial state.
+f.Start()
 ```

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ go get github.com/edge/fsm
 ctx := context.Background()
 f := fsm.New().WithContext(ctx)
 
-// Wildcard states are useful for transitioning to an Error or Shutdown state.
-f.NewState().From("*").To("ERROR").OnEnter(func(*fsm.State) {
+// FromAny states are useful for transitioning to an Error, Shutdown or other universally accessible states.
+f.NewState().FromAny().To("ERROR").OnEnter(func(*fsm.State) {
 	// Do something
 })
 
@@ -27,6 +27,11 @@ f.NewState().From("*").To("ERROR").OnEnter(func(*fsm.State) {
 f.NewState().From("INITIALIZING").To("READY").OnEnter(func(*fsm.State) {
 	// Do something here
 }).Parallel(true)
+
+// FromStart identifies transitions that can come from the launch state.
+f.NewState().FromStart().To("READY").OnEnter(func(*fsm.State) {
+	// Do something here
+})
 
 // Each state has a context that is closed before the state changes. You can use this with methods called within the state OnEnter method.
 f.NewState().From("FETCHING_DATA").To("STARTING_SERVER").OnEnter(func(st *fsm.State) {

--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ go get github.com/edge/fsm
 ctx := context.Background()
 f := fsm.New().WithContext(ctx)
 
-// FromAny states are useful for transitioning to an Error, Shutdown or other universally accessible states.
+// FromAny states are useful for transitioning to
+// an Error, Shutdown or other universally accessible states.
 f.NewState().FromAny().To("ERROR").OnEnter(func(*fsm.State) {
 	// Do something
 })
@@ -33,7 +34,8 @@ f.NewState().FromStart().To("READY").OnEnter(func(*fsm.State) {
 	// Do something here
 })
 
-// Each state has a context that is closed before the state changes. You can use this with methods called within the state OnEnter method.
+// Each state has a context that is closed before the state changes.
+// You can use this with methods called within the state OnEnter method.
 f.NewState().From("FETCHING_DATA").To("STARTING_SERVER").OnEnter(func(st *fsm.State) {
 	doSomething(st.Context())
 })

--- a/fsm.go
+++ b/fsm.go
@@ -148,6 +148,11 @@ func (s *StateMachine) OnStart(f func(s *State)) {
 
 // Start launches the state machine
 func (s *StateMachine) Start() error {
+	// Initialize if not yet initialized.
+	if !s.initialized {
+		s.Initialize()
+	}
+
 	if s.onStart == nil {
 		return errors.New("Finite State Machine is missing 'OnStart' method")
 	}
@@ -227,10 +232,6 @@ func (s *StateMachine) Initialize() {
 
 // Transition changes the state when permissible.
 func (s *StateMachine) Transition(to string) (err error) {
-	if !s.initialized {
-		s.Initialize()
-	}
-
 	// Ignore transitions to the same state.
 	if s.Match(to) {
 		return

--- a/fsm.go
+++ b/fsm.go
@@ -5,6 +5,7 @@ package fsm
 
 import (
 	"context"
+	"errors"
 	"fmt"
 )
 
@@ -13,9 +14,14 @@ type StateMachine struct {
 	CurrentState *State
 	States       []*State
 	transitions  chan *Transition
+	// beforeFn runs before the state is changes.
+	beforeFn func(*Transition)
+	// onStart is the function called when the state machine starts.
+	onStart func(*State)
 
-	ctx    context.Context
-	cancel context.CancelFunc
+	initialized bool
+	ctx         context.Context
+	cancel      context.CancelFunc
 }
 
 // State contains state configuration.
@@ -27,10 +33,12 @@ type State struct {
 	onEnterFunc func(*State)
 
 	// parallel decides whnever the onEnterFunc should be called in a new goroutine.
-	parallel bool
-
-	ctx    context.Context
-	cancel context.CancelFunc
+	parallel  bool
+	isStart   bool
+	fromAny   bool
+	fromStart bool
+	ctx       context.Context
+	cancel    context.CancelFunc
 }
 
 // Transition contains transition information.
@@ -45,6 +53,18 @@ func (st *State) To(dn string) *State {
 	return st
 }
 
+// FromAny allows the state to be transitioned to from any other state.
+func (st *State) FromAny() *State {
+	st.fromAny = true
+	return st
+}
+
+// FromStart allows the state to be transitioned to from the starting state.
+func (st *State) FromStart() *State {
+	st.fromStart = true
+	return st
+}
+
 // From assigns a Source to the State.
 func (st *State) From(src ...string) *State {
 	st.Source = src
@@ -54,6 +74,12 @@ func (st *State) From(src ...string) *State {
 // Transitions returns the transition channels.
 func (s *StateMachine) Transitions() <-chan *Transition {
 	return s.transitions
+}
+
+// BeforeTransition sets an action to be called before state transition is executed.
+func (s *StateMachine) BeforeTransition(f func(*Transition)) {
+	// Store the method.
+	s.beforeFn = f
 }
 
 // OnEnter setups the function to be called when a state is entered.
@@ -115,6 +141,26 @@ func (s *StateMachine) Exists() bool {
 	return s.CurrentState != nil
 }
 
+// OnStart defines a starting method.
+func (s *StateMachine) OnStart(f func(s *State)) {
+	s.onStart = f
+}
+
+// Start launches the state machine
+func (s *StateMachine) Start() error {
+	if s.onStart == nil {
+		return errors.New("Finite State Machine is missing 'OnStart' method")
+	}
+
+	state := &State{isStart: true}
+	state.ctx, state.cancel = context.WithCancel(s.ctx)
+	s.CurrentState = state
+
+	s.onStart(state)
+
+	return nil
+}
+
 // Name returns the current States destination name.
 func (s *StateMachine) Name() string {
 	if s.Exists() {
@@ -131,7 +177,14 @@ func (s *StateMachine) IsValidStateChange(name string) (*State, error) {
 		return st, err
 	}
 
-	if !s.Exists() || st.Source[0] == "*" {
+	// This state accepts transitions from any other state.
+	if st.fromAny {
+		return st, nil
+	}
+
+	// The current state is the starting state
+	// and this state allows transitions from the starting state.
+	if s.CurrentState.isStart && st.fromStart {
 		return st, nil
 	}
 
@@ -144,8 +197,40 @@ func (s *StateMachine) IsValidStateChange(name string) (*State, error) {
 	return st, fmt.Errorf("Invalid state change: %v > %v", s.CurrentState.Destination, st.Destination)
 }
 
+// Initialize starts the transition process.
+func (s *StateMachine) Initialize() {
+	if s.initialized {
+		return
+	}
+
+	s.initialized = true
+
+	go func() {
+		for {
+			select {
+			case <-s.ctx.Done():
+				return
+			case t := <-s.transitions:
+				if s.ctx.Err() != nil {
+					return
+				}
+
+				if s.beforeFn != nil {
+					s.beforeFn(t)
+				}
+
+				t.Do()
+			}
+		}
+	}()
+}
+
 // Transition changes the state when permissible.
 func (s *StateMachine) Transition(to string) (err error) {
+	if !s.initialized {
+		s.Initialize()
+	}
+
 	// Ignore transitions to the same state.
 	if s.Match(to) {
 		return
@@ -177,6 +262,9 @@ func (s *StateMachine) Transition(to string) (err error) {
 	if state.parallel {
 		go tr.Do()
 	} else {
+		if s.ctx != nil && s.ctx.Err() != nil {
+			return
+		}
 		s.transitions <- tr
 	}
 	s.CurrentState = state

--- a/fsm.go
+++ b/fsm.go
@@ -103,8 +103,8 @@ func (st *State) Context() context.Context {
 	return context.Background()
 }
 
-// Do executes the transition by exiting the previous state, and entering the new one.
-func (t *Transition) Do() {
+// do executes the transition by exiting the previous state, and entering the new one.
+func (t *Transition) do() {
 	if t.To.onEnterFunc != nil {
 		t.To.onEnterFunc(t.To)
 	}
@@ -219,7 +219,7 @@ func (s *StateMachine) Initialize() {
 					s.beforeFn(t)
 				}
 
-				t.Do()
+				t.do()
 			}
 		}
 	}()
@@ -260,7 +260,7 @@ func (s *StateMachine) Transition(to string) (err error) {
 	}
 
 	if state.parallel {
-		go tr.Do()
+		go tr.do()
 	} else {
 		if s.ctx != nil && s.ctx.Err() != nil {
 			return

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/edge/fsm
 
-go 1.13
+go 1.15
+
+require github.com/stretchr/testify v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
+github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=


### PR DESCRIPTION
- Remove wildcard `From` and replace with `FromAny`
- `OnStart` method defines an initial state
- `Start` runs the start method
- `FromStart` allows transition from the initial starting state to the new State
- `BeforeTransition` runs a function before the transition is performed